### PR TITLE
[Fix] Order of sources influences insertId outcome

### DIFF
--- a/OpenXmlPowerTools/DocumentBuilder.cs
+++ b/OpenXmlPowerTools/DocumentBuilder.cs
@@ -372,7 +372,7 @@ namespace OpenXmlPowerTools
                 }
 
                 int sourceNum = 0;
-                foreach (Source source in sources)
+                foreach (Source source in sources.OrderBy(src => src.InsertId != null))
                 {
                     if (source.InsertId != null)
                     {


### PR DESCRIPTION
When doing a BuildDocument, Source objects without Id should be processed first, to ensure Source object with insertId can be inserted.

I do an Orderby to ensure the 'optimized' order of execution.
