### PR TITLE
parse css numbers using the invariant culture

### DIFF
--- a/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
+++ b/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
@@ -2640,7 +2640,7 @@ namespace OpenXmlPowerTools.HtmlToWml
             if (width.IsNotAuto && height.IsAuto)
             {
                 Emu widthInEmus = (Emu)width;
-                double percentChange = widthInEmus / cx;
+                double percentChange = (float)widthInEmus / (float)cx;
                 cx = widthInEmus;
                 cy = (long)(cy * percentChange);
                 return new SizeEmu(cx, cy);

--- a/OpenXmlPowerTools/HtmlToWmlCssApplier.cs
+++ b/OpenXmlPowerTools/HtmlToWmlCssApplier.cs
@@ -582,9 +582,9 @@ namespace OpenXmlPowerTools.HtmlToWml
                             {
                                 string s1 = settings.DefaultBlockContentMargin.Substring(0, settings.DefaultBlockContentMargin.Length - 2);
                                 double d1;
-                                if (double.TryParse(s1, out d1))
+                                if (double.TryParse(s1, NumberStyles.Float, CultureInfo.InvariantCulture, out d1))
                                 {
-                                    return new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = d1.ToString(), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT } } };
+                                    return new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = d1.ToString(CultureInfo.InvariantCulture), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT } } };
                                 }
                             }
                             throw new OpenXmlPowerToolsException("invalid setting");
@@ -1431,7 +1431,7 @@ namespace OpenXmlPowerTools.HtmlToWml
             if (unit == CssUnit.Percent)
             {
                 double ptSize;
-                if (!double.TryParse(lengthForPercentage.Terms.First().Value, out ptSize))
+                if (!double.TryParse(lengthForPercentage.Terms.First().Value, NumberStyles.Float, CultureInfo.InvariantCulture, out ptSize))
                     throw new OpenXmlPowerToolsException("did not return a double?");
                 newPtSize = ptSize * decValue / 100d;
             }
@@ -1439,7 +1439,7 @@ namespace OpenXmlPowerTools.HtmlToWml
             {
                 CssExpression fontSize = GetComputedPropertyValue(null, element, "font-size", settings);
                 double decFontSize;
-                if (!double.TryParse(fontSize.Terms.First().Value, out decFontSize))
+                if (!double.TryParse(fontSize.Terms.First().Value, NumberStyles.Float, CultureInfo.InvariantCulture, out decFontSize))
                     throw new OpenXmlPowerToolsException("Internal error");
                 newPtSize = (unit == CssUnit.EM) ? decFontSize * decValue : decFontSize * decValue / 2;
             }
@@ -1480,7 +1480,7 @@ namespace OpenXmlPowerTools.HtmlToWml
             {
                 CssExpression parentFontSize = GetComputedPropertyValue(null, element.Parent, "font-size", settings);
                 double ptSize;
-                if (!double.TryParse(parentFontSize.Terms.First().Value, out ptSize))
+                if (!double.TryParse(parentFontSize.Terms.First().Value, NumberStyles.Float, CultureInfo.InvariantCulture, out ptSize))
                     throw new OpenXmlPowerToolsException("did not return a double?");
                 double newPtSize2 = 0;
                 if (value == "larger")
@@ -1516,14 +1516,14 @@ namespace OpenXmlPowerTools.HtmlToWml
                 return new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = newPtSize2.ToString(), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } };
             }
             double decValue;
-            if (!double.TryParse(value, out decValue))
+            if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out decValue))
                 throw new OpenXmlPowerToolsException("em value did not parse");
             double? newPtSize = null;
             if (unit == CssUnit.EM || unit == CssUnit.EX || unit == CssUnit.Percent)
             {
                 CssExpression parentFontSize = GetComputedPropertyValue(null, element.Parent, "font-size", settings);
                 double ptSize;
-                if (!double.TryParse(parentFontSize.Terms.First().Value, out ptSize))
+                if (!double.TryParse(parentFontSize.Terms.First().Value, NumberStyles.Float, CultureInfo.InvariantCulture, out ptSize))
                     throw new OpenXmlPowerToolsException("did not return a double?");
                 if (unit == CssUnit.EM)
                     newPtSize = ptSize * decValue;

--- a/OpenXmlPowerTools/OpenXmlPowerTools.csproj
+++ b/OpenXmlPowerTools/OpenXmlPowerTools.csproj
@@ -37,9 +37,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.IO.Packaging">
-      <HintPath>..\..\Open-Xml-SDK\DocumentFormat.OpenXml\bin\Debug\System.IO.Packaging.dll</HintPath>
-    </Reference>
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\Windows\assembly\GAC_MSIL\System.Management.Automation\1.0.0.0__31bf3856ad364e35\System.Management.Automation.dll</HintPath>


### PR DESCRIPTION
If current culture does not have '.' as decimal separator HtmlToWmlCssApplier.cs will fail to parse css numbers such as 33.3%. Fixed by always parsing with the Invariant Culture.