### PR TITLE
Use net35 / c# 3.0 language features

### DIFF
--- a/OpenXmlPowerTools.Tests/MarkupSimplifierTests.cs
+++ b/OpenXmlPowerTools.Tests/MarkupSimplifierTests.cs
@@ -133,10 +133,10 @@ namespace OpenXmlPowerTools.Tests
             XDocument partDocument = XDocument.Parse(GoBackBookmarkDocumentXmlString);
             Assert.True(partDocument
                 .Descendants(W.bookmarkStart)
-                .Any(e => e.Attribute(W.name)?.Value == "_GoBack" && e.Attribute(W.id)?.Value == "0"));
+                .Any(e => e.Attribute(W.name).Value == "_GoBack" && e.Attribute(W.id).Value == "0"));
             Assert.True(partDocument
                 .Descendants(W.bookmarkEnd)
-                .Any(e => e.Attribute(W.id)?.Value == "0"));
+                .Any(e => e.Attribute(W.id).Value == "0"));
 
             using (var stream = new MemoryStream())
             using (WordprocessingDocument wordDocument = WordprocessingDocument.Create(stream, DocumentType))

--- a/OpenXmlPowerTools.Tests/OpenXmlRegexTests.cs
+++ b/OpenXmlPowerTools.Tests/OpenXmlRegexTests.cs
@@ -126,7 +126,7 @@ namespace OpenXmlPowerTools.Tests
         private static string InnerText(XContainer e)
         {
             return e.Descendants(W.r)
-                .Where(r => r.Parent?.Name != W.del)
+                .Where(r => r.Parent.Name != W.del)
                 .Select(UnicodeMapper.RunToString)
                 .StringConcatenate();
         }
@@ -267,8 +267,8 @@ namespace OpenXmlPowerTools.Tests
 
                 Assert.True(p.Descendants(W.ins).Any(
                     ins => ins.Descendants(W.sym).Any(
-                        sym => sym.Attribute(W.font)?.Value == "Wingdings" && 
-                               sym.Attribute(W._char)?.Value == "F028")));
+                        sym => sym.Attribute(W.font).Value == "Wingdings" && 
+                               sym.Attribute(W._char).Value == "F028")));
             }
         }
     }

--- a/OpenXmlPowerTools.Tests/UnicodeMapperTests.cs
+++ b/OpenXmlPowerTools.Tests/UnicodeMapperTests.cs
@@ -60,7 +60,7 @@ namespace OpenXmlPowerTools.Tests
 
             XElement element = UnicodeMapper.CharToRunChild(UnicodeMapper.FormFeed);
             Assert.Equal(W.br, element.Name);
-            Assert.Equal("page", element.Attribute(W.type)?.Value);
+            Assert.Equal("page", element.Attribute(W.type).Value);
 
             Assert.Equal(W.br, UnicodeMapper.CharToRunChild('\r').Name);
         }
@@ -113,11 +113,11 @@ namespace OpenXmlPowerTools.Tests
             Assert.Equal(charFromSym1, charFromSym3);
             Assert.NotEqual(charFromSym1, charFromSym4);
 
-            Assert.Equal("F028", symFromChar1.Attribute(W._char)?.Value);
-            Assert.Equal("Wingdings", symFromChar1.Attribute(W.font)?.Value);
+            Assert.Equal("F028", symFromChar1.Attribute(W._char).Value);
+            Assert.Equal("Wingdings", symFromChar1.Attribute(W.font).Value);
 
-            Assert.Equal("F028", symFromChar4.Attribute(W._char)?.Value);
-            Assert.Equal("Webdings", symFromChar4.Attribute(W.font)?.Value);
+            Assert.Equal("F028", symFromChar4.Attribute(W._char).Value);
+            Assert.Equal("Webdings", symFromChar4.Attribute(W.font).Value);
         }
 
         [Fact]

--- a/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
+++ b/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
@@ -653,9 +653,9 @@ namespace OpenXmlPowerTools.HtmlToWml
             foreach (XElement run in runsWithWidth)
             {
                 XElement p = run.Ancestors(W.p).FirstOrDefault();
-                XElement pPr = p?.Element(W.pPr);
+                XElement pPr = p != null ? p.Element(W.pPr) : null;
                 XElement rPr = run.Element(W.rPr);
-                XElement rFonts = rPr?.Element(W.rFonts);
+                XElement rFonts = rPr != null ? rPr.Element(W.rFonts) : null;
                 string str = run.Descendants(W.t).Select(t => (string) t).StringConcatenate();
                 if ((pPr == null) || (rPr == null) || (rFonts == null) || (str == "")) continue;
 
@@ -689,16 +689,26 @@ namespace OpenXmlPowerTools.HtmlToWml
                 }
 
                 if (fontType != null)
-                    if (run.Attribute(PtOpenXml.FontName) == null)
+                {
+                    XAttribute fontNameAttribute = run.Attribute(PtOpenXml.FontName);
+                    if (fontNameAttribute == null)
                         run.Add(new XAttribute(PtOpenXml.FontName, fontType));
                     else
-                        run.Attribute(PtOpenXml.FontName)?.SetValue(fontType);
+                        fontNameAttribute.SetValue(fontType);
+                }
 
                 if (languageType != null)
-                    if (run.Attribute(PtOpenXml.LanguageType) == null)
+                {
+                    XAttribute languageTypeAttribute = run.Attribute(PtOpenXml.LanguageType);
+                    if (languageTypeAttribute == null)
+                    {
                         run.Add(new XAttribute(PtOpenXml.LanguageType, languageType));
+                    }
                     else
-                        run.Attribute(PtOpenXml.LanguageType)?.SetValue(languageType);
+                    {
+                        languageTypeAttribute.SetValue(languageType);
+                    }
+                }
 
                 int pixWidth = CalcWidthOfRunInPixels(run) ?? 0;
 

--- a/OpenXmlPowerTools/OpenXmlRegex.cs
+++ b/OpenXmlPowerTools/OpenXmlRegex.cs
@@ -129,8 +129,8 @@ namespace OpenXmlPowerTools
             Func<XElement, Match, bool> callback, bool trackRevisions, string revisionTrackingAuthor,
             bool coalesceContent)
         {
-            if (content == null) throw new ArgumentNullException(nameof(content));
-            if (regex == null) throw new ArgumentNullException(nameof(regex));
+            if (content == null) throw new ArgumentNullException("content");
+            if (regex == null) throw new ArgumentNullException("regex");
 
             IEnumerable<XElement> contentList = content as IList<XElement> ?? content.ToList();
 

--- a/OpenXmlPowerTools/OpenXmlRegex.cs
+++ b/OpenXmlPowerTools/OpenXmlRegex.cs
@@ -72,7 +72,7 @@ namespace OpenXmlPowerTools
             return ReplaceInternal(content, regex, null,
                 (x, m) =>
                 {
-                    found?.Invoke(x, m);
+                    if (found != null) found.Invoke(x, m);
                     return true;
                 },
                 false, null, true);
@@ -213,7 +213,7 @@ namespace OpenXmlPowerTools
 
                 string preliminaryContent = paragraph
                     .DescendantsTrimmed(W.txbxContent)
-                    .Where(d => d.Name == W.r && d.Parent?.Name != W.del)
+                    .Where(d => d.Name == W.r && (d.Parent == null || d.Parent.Name != W.del))
                     .Select(UnicodeMapper.RunToString)
                     .StringConcatenate();
                 if (regex.IsMatch(preliminaryContent))
@@ -225,7 +225,7 @@ namespace OpenXmlPowerTools
 
                     IEnumerable<XElement> runsTrimmed = paragraphWithSplitRuns
                         .DescendantsTrimmed(W.txbxContent)
-                        .Where(d => d.Name == W.r && d.Parent?.Name != W.del);
+                        .Where(d => d.Name == W.r && (d.Parent == null || d.Parent.Name != W.del));
 
                     var charsAndRuns = runsTrimmed
                         .Select(r => new { Ch = UnicodeMapper.RunToString(r), r })
@@ -281,41 +281,45 @@ namespace OpenXmlPowerTools
                                     new XAttribute(W.date, DateTime.UtcNow.ToString("s") + "Z"),
                                     newRuns);
 
-                                if (firstRun.Parent?.Name == W.ins)
-                                    firstRun.Parent?.AddBeforeSelf(newIns);
+                                if (firstRun.Parent != null && firstRun.Parent.Name == W.ins)
+                                    firstRun.Parent.AddBeforeSelf(newIns);
                                 else
                                     firstRun.AddBeforeSelf(newIns);
                             }
 
                             foreach (XElement run in runCollection)
                             {
-                                bool isInIns = run.Parent?.Name == W.ins;
+                                bool isInIns = run.Parent != null && run.Parent.Name == W.ins;
                                 if (isInIns)
                                 {
                                     XElement parentIns = run.Parent;
-                                    if ((string) parentIns.Attributes(W.author).FirstOrDefault() ==
-                                        revisionTrackingAuthor)
+                                    XElement grandParentParagraph = parentIns.Parent;
+                                    if (grandParentParagraph != null)
                                     {
-                                        List<XElement> parentInsSiblings = parentIns.Parent?
-                                            .Elements()
-                                            .Where(c => c != parentIns)
-                                            .ToList();
-                                        parentIns.Parent?.ReplaceNodes(parentInsSiblings);
-                                    }
-                                    else
-                                    {
-                                        List<XElement> parentInsSiblings = parentIns.Parent?
-                                            .Elements()
-                                            .Select(c => c == parentIns
-                                                ? new XElement(W.ins,
-                                                    parentIns.Attributes(),
-                                                    new XElement(W.del,
-                                                        new XAttribute(W.author, revisionTrackingAuthor),
-                                                        new XAttribute(W.date, DateTime.UtcNow.ToString("s") + "Z"),
-                                                        parentIns.Elements().Select(TransformToDelText)))
-                                                : c)
-                                            .ToList();
-                                        parentIns.Parent?.ReplaceNodes(parentInsSiblings);
+                                        if ((string) parentIns.Attributes(W.author).FirstOrDefault() ==
+                                            revisionTrackingAuthor)
+                                        {
+                                            List<XElement> parentInsSiblings = grandParentParagraph
+                                                .Elements()
+                                                .Where(c => c != parentIns)
+                                                .ToList();
+                                            grandParentParagraph.ReplaceNodes(parentInsSiblings);
+                                        }
+                                        else
+                                        {
+                                            List<XElement> parentInsSiblings = grandParentParagraph
+                                                .Elements()
+                                                .Select(c => c == parentIns
+                                                    ? new XElement(W.ins,
+                                                        parentIns.Attributes(),
+                                                        new XElement(W.del,
+                                                            new XAttribute(W.author, revisionTrackingAuthor),
+                                                            new XAttribute(W.date, DateTime.UtcNow.ToString("s") + "Z"),
+                                                            parentIns.Elements().Select(TransformToDelText)))
+                                                    : c)
+                                                .ToList();
+                                            grandParentParagraph.ReplaceNodes(parentInsSiblings);
+                                        }
                                     }
                                 }
                                 else
@@ -331,8 +335,8 @@ namespace OpenXmlPowerTools
                         else // not tracked revisions
                         {
                             foreach (XElement runToDelete in runCollection.Skip(1).ToList())
-                                if (runToDelete.Parent?.Name == W.ins)
-                                    runToDelete.Parent?.Remove();
+                                if (runToDelete.Parent != null && runToDelete.Parent.Name == W.ins)
+                                    runToDelete.Parent.Remove();
                                 else
                                     runToDelete.Remove();
 
@@ -342,8 +346,8 @@ namespace OpenXmlPowerTools
                             string newTextValue = match.Result(replacement);
                             List<XElement> newRuns = UnicodeMapper.StringToCoalescedRunList(newTextValue,
                                 firstRunProperties);
-                            if (firstRun.Parent?.Name == W.ins)
-                                firstRun.Parent?.ReplaceWith(newRuns);
+                            if (firstRun.Parent != null && firstRun.Parent.Name == W.ins)
+                                firstRun.Parent.ReplaceWith(newRuns);
                             else
                                 firstRun.ReplaceWith(newRuns);
                         }
@@ -387,7 +391,9 @@ namespace OpenXmlPowerTools
                     .Select(c =>
                     {
                         var elements = c as IEnumerable<XElement>;
-                        return elements?.Select(ixc => new XElement(W.ins, element.Attributes(), ixc)) ?? c;
+                        return elements != null
+                            ? elements.Select(ixc => new XElement(W.ins, element.Attributes(), ixc))
+                            : c;
                     })
                     .ToList();
                 return collectionOfIns;
@@ -453,7 +459,7 @@ namespace OpenXmlPowerTools
                 var charsAndRuns = runsTrimmed
                     .Select(r =>
                         r.Element(A.t) != null
-                            ? new { Ch = r.Element(A.t)?.Value, r }
+                            ? new { Ch = r.Element(A.t).Value, r }
                             : new { Ch = "\x01", r })
                     .ToList();
 
@@ -515,10 +521,9 @@ namespace OpenXmlPowerTools
                                     return DontConsolidate;
                                 if ((ce.Elements().Count(e => e.Name != A.rPr) != 1) || (ce.Element(A.t) == null))
                                     return DontConsolidate;
-                                if (ce.Element(A.rPr) == null)
-                                    return "";
 
-                                return ce.Element(A.rPr)?.ToString(SaveOptions.None);
+                                XElement rPr = ce.Element(A.rPr);
+                                return rPr == null ? "" : rPr.ToString(SaveOptions.None);
                             });
                     var paragraphWithConsolidatedRuns = new XElement(A.p,
                         groupedAdjacentRunsWithIdenticalFormatting.Select(g =>
@@ -526,7 +531,7 @@ namespace OpenXmlPowerTools
                             if (g.Key == DontConsolidate)
                                 return (object) g;
 
-                            string textValue = g.Select(r => r.Element(A.t)?.Value).StringConcatenate();
+                            string textValue = g.Select(r => r.Element(A.t).Value).StringConcatenate();
                             XAttribute xs = XmlUtil.GetXmlSpaceAttribute(textValue);
                             return new XElement(A.r,
                                 g.First().Elements(A.rPr),

--- a/OpenXmlPowerTools/PtOpenXmlUtil.cs
+++ b/OpenXmlPowerTools/PtOpenXmlUtil.cs
@@ -80,7 +80,7 @@ namespace OpenXmlPowerTools
         /// </param>
         public static void RemovePowerToolsAnnotations(this OpenXmlPackage package)
         {
-            if (package == null) throw new ArgumentNullException(nameof(package));
+            if (package == null) throw new ArgumentNullException("package");
 
             foreach (OpenXmlPart part in package.GetAllParts())
                 part.RemovePowerToolsAnnotations();
@@ -105,7 +105,7 @@ namespace OpenXmlPowerTools
         /// <param name="part">An <see cref="OpenXmlPart"/>, e.g., a <see cref="MainDocumentPart"/>.</param>
         public static void RemovePowerToolsAnnotations(this OpenXmlPart part)
         {
-            if (part == null) throw new ArgumentNullException(nameof(part));
+            if (part == null) throw new ArgumentNullException("part");
 
             part.RemoveAnnotations<XDocument>();
             part.RemoveAnnotations<XmlNamespaceManager>();
@@ -113,7 +113,7 @@ namespace OpenXmlPowerTools
 
         public static XDocument GetXDocument(this OpenXmlPart part)
         {
-            if (part == null) throw new ArgumentNullException(nameof(part));
+            if (part == null) throw new ArgumentNullException("part");
 
             XDocument partXDocument = part.Annotation<XDocument>();
             if (partXDocument != null) return partXDocument;
@@ -138,7 +138,7 @@ namespace OpenXmlPowerTools
 
         public static XDocument GetXDocument(this OpenXmlPart part, out XmlNamespaceManager namespaceManager)
         {
-            if (part == null) throw new ArgumentNullException(nameof(part));
+            if (part == null) throw new ArgumentNullException("part");
 
             namespaceManager = part.Annotation<XmlNamespaceManager>();
             XDocument partXDocument = part.Annotation<XDocument>();
@@ -181,7 +181,7 @@ namespace OpenXmlPowerTools
 
         public static void PutXDocument(this OpenXmlPart part)
         {
-            if (part == null) throw new ArgumentNullException(nameof(part));
+            if (part == null) throw new ArgumentNullException("part");
 
             XDocument partXDocument = part.GetXDocument();
             if (partXDocument != null)
@@ -203,7 +203,7 @@ namespace OpenXmlPowerTools
 
         public static void PutXDocumentWithFormatting(this OpenXmlPart part)
         {
-            if (part == null) throw new ArgumentNullException(nameof(part));
+            if (part == null) throw new ArgumentNullException("part");
 
             XDocument partXDocument = part.GetXDocument();
             if (partXDocument != null)
@@ -226,8 +226,8 @@ namespace OpenXmlPowerTools
 
         public static void PutXDocument(this OpenXmlPart part, XDocument document)
         {
-            if (part == null) throw new ArgumentNullException(nameof(part));
-            if (document == null) throw new ArgumentNullException(nameof(document));
+            if (part == null) throw new ArgumentNullException("part");
+            if (document == null) throw new ArgumentNullException("document");
 
             using (Stream partStream = part.GetStream(FileMode.Create, FileAccess.Write))
             using (XmlWriter partXmlWriter = XmlWriter.Create(partStream))

--- a/OpenXmlPowerTools/PtOpenXmlUtil.cs
+++ b/OpenXmlPowerTools/PtOpenXmlUtil.cs
@@ -197,7 +197,7 @@ namespace OpenXmlPowerTools
 #endif
                 // To be able to access the DOM tree using the strictly typed classes, we need
                 // to reload it after having written an XDocument to the part.
-                if (ReloadRootElementOnPut) part.RootElement?.Reload();
+                if (ReloadRootElementOnPut && part.RootElement != null) part.RootElement.Reload();
             }
         }
 
@@ -219,7 +219,7 @@ namespace OpenXmlPowerTools
 
                     // To be able to access the DOM tree using the strictly typed classes, we need
                     // to reload it after having written an XDocument to the part.
-                    if (ReloadRootElementOnPut) part.RootElement?.Reload();
+                    if (ReloadRootElementOnPut && part.RootElement != null) part.RootElement.Reload();
                 }
             }
         }
@@ -238,7 +238,7 @@ namespace OpenXmlPowerTools
 
             // To be able to access the DOM tree using the strictly typed classes, we need
             // to reload it after having written an XDocument to the part.
-            if (ReloadRootElementOnPut) part.RootElement?.Reload();
+            if (ReloadRootElementOnPut && part.RootElement != null) part.RootElement.Reload();
         }
 
         private static XmlNamespaceManager GetManagerFromXDocument(XDocument xDocument)
@@ -923,11 +923,14 @@ namespace OpenXmlPowerTools
                             if (ce.Elements().Count(e => e.Name != W.rPr) != 1)
                                 return dontConsolidate;
 
+                            XElement rPr = ce.Element(W.rPr);
+                            string rPrString = rPr != null ? rPr.ToString(SaveOptions.None) : string.Empty;
+
                             if (ce.Element(W.t) != null)
-                                return "Wt" + ce.Element(W.rPr)?.ToString(SaveOptions.None);
+                                return "Wt" + rPrString;
 
                             if (ce.Element(W.instrText) != null)
-                                return "WinstrText" + ce.Element(W.rPr)?.ToString(SaveOptions.None);
+                                return "WinstrText" + rPrString;
 
                             return dontConsolidate;
                         }
@@ -942,13 +945,14 @@ namespace OpenXmlPowerTools
                                     return dontConsolidate;
 
                                 XAttribute dateIns = ce.Attribute(W.date);
-                                XAttribute dateDel = ce.Element(W.del)?.Attribute(W.date);
+                                XElement del = ce.Element(W.del);
+                                XAttribute dateDel = del.Attribute(W.date);
 
-                                string authorIns = (string) ce.Attribute(W.author) ?? "";
+                                string authorIns = (string) ce.Attribute(W.author) ?? string.Empty;
                                 string dateInsString = dateIns != null
                                     ? ((DateTime) dateIns).ToString("s")
                                     : string.Empty;
-                                string authorDel = (string) ce.Element(W.del)?.Attribute(W.author) ?? string.Empty;
+                                string authorDel = (string) del.Attribute(W.author) ?? string.Empty;
                                 string dateDelString = dateDel != null
                                     ? ((DateTime) dateDel).ToString("s")
                                     : string.Empty;

--- a/OpenXmlPowerTools/PtUtil.cs
+++ b/OpenXmlPowerTools/PtUtil.cs
@@ -942,7 +942,7 @@ namespace OpenXmlPowerTools
                 }
                 else
                 {
-                    throw new ArgumentException("Invalid executable path.", nameof(executablePath));
+                    throw new ArgumentException("Invalid executable path.", "executablePath");
                 }
             }
             catch (Exception e)

--- a/OpenXmlPowerTools/PtUtil.cs
+++ b/OpenXmlPowerTools/PtUtil.cs
@@ -57,7 +57,7 @@ namespace OpenXmlPowerTools
 
             XElement newXElement = XElement.Parse(newElement);
             newXElement.Attributes().Where(a => a.IsNamespaceDeclaration).Remove();
-            partXDoc.Root?.Add(newXElement);
+            if (partXDoc.Root != null) partXDoc.Root.Add(newXElement);
         }
     }
 
@@ -670,7 +670,7 @@ namespace OpenXmlPowerTools
 
         private static string GetQName(XAttribute xa)
         {
-            string prefix = xa.Parent?.GetPrefixOfNamespace(xa.Name.Namespace);
+            string prefix = xa.Parent != null ? xa.Parent.GetPrefixOfNamespace(xa.Name.Namespace) : null;
             if (xa.Name.Namespace == XNamespace.None || prefix == null)
                 return xa.Name.ToString();
 
@@ -757,9 +757,7 @@ namespace OpenXmlPowerTools
                     return
                         "/" +
                         (
-                            pi.Document?.Nodes()
-                                .OfType<XProcessingInstruction>()
-                                .Count() != 1
+                            pi.Document != null && pi.Document.Nodes().OfType<XProcessingInstruction>().Count() != 1
                                 ? "processing-instruction()[" +
                                   (pi
                                        .NodesBeforeSelf()

--- a/OpenXmlPowerTools/UnicodeMapper.cs
+++ b/OpenXmlPowerTools/UnicodeMapper.cs
@@ -73,7 +73,7 @@ namespace OpenXmlPowerTools
         /// <returns>The corresponding Unicode value or U+0001.</returns>
         public static string RunToString(XElement element)
         {
-            if (element.Name == W.r && element.Parent?.Name != W.del)
+            if (element.Name == W.r && (element.Parent == null || element.Parent.Name != W.del))
                 return element.Elements()
                     .Where(e => StringifiedRunElements.Contains(e.Name))
                     .Select(RunToString)
@@ -87,7 +87,8 @@ namespace OpenXmlPowerTools
             // unicode characters.
             if (element.Name == W.br)
             {
-                string type = element.Attribute(W.type)?.Value;
+                XAttribute typeAttribute = element.Attribute(W.type);
+                string type = typeAttribute != null ? typeAttribute.Value : null;
                 if (type == null || type == "textWrapping")
                     return CarriageReturn.ToString();
                 if (type == "page")
@@ -204,11 +205,13 @@ namespace OpenXmlPowerTools
             if (sym.Name != W.sym)
                 throw new ArgumentException($"Not a w:sym: {sym.Name}", "sym");
 
-            string fontAttributeValue = sym.Attribute(W.font)?.Value;
+            XAttribute fontAttribute = sym.Attribute(W.font);
+            string fontAttributeValue = fontAttribute != null ? fontAttribute.Value : null;
             if (fontAttributeValue == null)
                 throw new ArgumentException("w:sym element has no w:font attribute.", "sym");
 
-            string charAttributeValue = sym.Attribute(W._char)?.Value;
+            XAttribute charAttribute = sym.Attribute(W._char);
+            string charAttributeValue = charAttribute != null ? charAttribute.Value : null;
             if (charAttributeValue == null)
                 throw new ArgumentException("w:sym element has no w:char attribute.", "sym");
 

--- a/OpenXmlPowerTools/UnicodeMapper.cs
+++ b/OpenXmlPowerTools/UnicodeMapper.cs
@@ -180,9 +180,9 @@ namespace OpenXmlPowerTools
         public static char SymToChar(string fontAttributeValue, string charAttributeValue)
         {
             if (string.IsNullOrEmpty(fontAttributeValue))
-                throw new ArgumentException("Argument is null or empty.", nameof(fontAttributeValue));
+                throw new ArgumentException("Argument is null or empty.", "fontAttributeValue");
             if (string.IsNullOrEmpty(charAttributeValue))
-                throw new ArgumentException("Argument is null or empty.", nameof(charAttributeValue));
+                throw new ArgumentException("Argument is null or empty.", "charAttributeValue");
 
             return SymToChar(new XElement(W.sym,
                 new XAttribute(W.font, fontAttributeValue),
@@ -200,17 +200,17 @@ namespace OpenXmlPowerTools
         public static char SymToChar(XElement sym)
         {
             if (sym == null)
-                throw new ArgumentNullException(nameof(sym));
+                throw new ArgumentNullException("sym");
             if (sym.Name != W.sym)
-                throw new ArgumentException($"Not a w:sym: {sym.Name}", nameof(sym));
+                throw new ArgumentException($"Not a w:sym: {sym.Name}", "sym");
 
             string fontAttributeValue = sym.Attribute(W.font)?.Value;
             if (fontAttributeValue == null)
-                throw new ArgumentException("w:sym element has no w:font attribute.", nameof(sym));
+                throw new ArgumentException("w:sym element has no w:font attribute.", "sym");
 
             string charAttributeValue = sym.Attribute(W._char)?.Value;
             if (charAttributeValue == null)
-                throw new ArgumentException("w:sym element has no w:char attribute.", nameof(sym));
+                throw new ArgumentException("w:sym element has no w:char attribute.", "sym");
 
             // Return Unicode value if it is in the dictionary.
             var standardizedSym = new XElement(W.sym,


### PR DESCRIPTION
@EricWhiteDev, as discussed by email, I have replaced the following two c# 6.0 language features introduced in the recent commits by corresponding c# 3.0 language constructs:

- nameof operators
- null-conditional operators (?.)

Should there be anything else that needs to be done to ensure source code compatibility with .NET 3.5 or C# 3.0, we can replace that as well.