### PR TITLE
Replace string interpolation

### DIFF
--- a/OpenXmlPowerTools.Tests/OpenXmlRegexTests.cs
+++ b/OpenXmlPowerTools.Tests/OpenXmlRegexTests.cs
@@ -156,7 +156,8 @@ namespace OpenXmlPowerTools.Tests
                 part.PutXDocument(partDocument);
 
                 IEnumerable<XElement> content = partDocument.Descendants(W.p);
-                var regex = new Regex($"{LeftDoubleQuotationMarks}(?<words>{Words}){RightDoubleQuotationMarks}");
+                var regex = new Regex(string.Format("{0}(?<words>{1}){2}", LeftDoubleQuotationMarks, Words,
+                    RightDoubleQuotationMarks));
                 int count = OpenXmlRegex.Replace(content, regex, "‘changed ${words}’", null);
 
                 p = partDocument.Descendants(W.p).First();
@@ -187,7 +188,8 @@ namespace OpenXmlPowerTools.Tests
                 part.PutXDocument(partDocument);
 
                 IEnumerable<XElement> content = partDocument.Descendants(W.p);
-                var regex = new Regex($"{LeftDoubleQuotationMarks}(?<words>{Words}){RightDoubleQuotationMarks}");
+                var regex = new Regex(string.Format("{0}(?<words>{1}){2}", LeftDoubleQuotationMarks, Words,
+                    RightDoubleQuotationMarks));
                 int count = OpenXmlRegex.Replace(content, regex, "‘changed ${words}’", null, true, "John Doe");
 
                 p = partDocument.Descendants(W.p).First();
@@ -224,7 +226,8 @@ namespace OpenXmlPowerTools.Tests
                 part.PutXDocument(partDocument);
 
                 IEnumerable<XElement> content = partDocument.Descendants(W.p);
-                var regex = new Regex($"{LeftDoubleQuotationMarks}(?<words>{Words}){RightDoubleQuotationMarks}");
+                var regex = new Regex(string.Format("{0}(?<words>{1}){2}", LeftDoubleQuotationMarks, Words,
+                    RightDoubleQuotationMarks));
                 int count = OpenXmlRegex.Replace(content, regex, "‘changed ${words}’", null, true, "John Doe");
 
                 p = partDocument.Descendants(W.p).First();

--- a/OpenXmlPowerTools/PtUtil.cs
+++ b/OpenXmlPowerTools/PtUtil.cs
@@ -46,7 +46,7 @@ namespace OpenXmlPowerTools
         public static string MakeValidXml(string p)
         {
             return p.Any(c => c < 0x20)
-                ? p.Select(c => c < 0x20 ? $"_{(int) c:X}_" : c.ToString()).StringConcatenate()
+                ? p.Select(c => c < 0x20 ? string.Format("_{0:X}_", (int) c) : c.ToString()).StringConcatenate()
                 : p;
         }
 
@@ -204,7 +204,8 @@ namespace OpenXmlPowerTools
             DateTime now = DateTime.Now;
             string dirName =
                 prefix +
-                $"-{now.Year - 2000:00}-{now.Month:00}-{now.Day:00}-{now.Hour:00}{now.Minute:00}{now.Second:00}";
+                string.Format("-{0:00}-{1:00}-{2:00}-{3:00}{4:00}{5:00}", now.Year - 2000, now.Month, now.Day, now.Hour,
+                    now.Minute, now.Second);
             return new DirectoryInfo(dirName);
         }
 
@@ -213,7 +214,8 @@ namespace OpenXmlPowerTools
             DateTime now = DateTime.Now;
             string fileName =
                 prefix +
-                $"-{now.Year - 2000:00}-{now.Month:00}-{now.Day:00}-{now.Hour:00}{now.Minute:00}{now.Second:00}" +
+                string.Format("-{0:00}-{1:00}-{2:00}-{3:00}{4:00}{5:00}", now.Year - 2000, now.Month, now.Day, now.Hour,
+                    now.Minute, now.Second) +
                 suffix;
             return new FileInfo(fileName);
         }
@@ -1072,7 +1074,7 @@ namespace OpenXmlPowerTools
         {
             if (Value.Substring(0, 1) == "#")
             {
-                string e = $"&{Value};";
+                string e = string.Format("&{0};", Value);
                 writer.WriteRaw(e);
             }
             else

--- a/OpenXmlPowerTools/UnicodeMapper.cs
+++ b/OpenXmlPowerTools/UnicodeMapper.cs
@@ -203,7 +203,7 @@ namespace OpenXmlPowerTools
             if (sym == null)
                 throw new ArgumentNullException("sym");
             if (sym.Name != W.sym)
-                throw new ArgumentException($"Not a w:sym: {sym.Name}", "sym");
+                throw new ArgumentException(string.Format("Not a w:sym: {0}", sym.Name), "sym");
 
             XAttribute fontAttribute = sym.Attribute(W.font);
             string fontAttributeValue = fontAttribute != null ? fontAttribute.Value : null;


### PR DESCRIPTION
This commit replaces string interpolation with the corresponding
string.Format() expression. This is done to retain compatibility with
.NET 3.5 and C# 3.0.