### PR TITLE
Reduce language level to C# 4.0

### DIFF
--- a/OpenXmlPowerTools.Tests/OpenXmlPowerTools.Tests.csproj.DotSettings
+++ b/OpenXmlPowerTools.Tests/OpenXmlPowerTools.Tests.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp40</s:String></wpf:ResourceDictionary>

--- a/OpenXmlPowerTools/MarkupSimplifier.cs
+++ b/OpenXmlPowerTools/MarkupSimplifier.cs
@@ -229,7 +229,7 @@ namespace OpenXmlPowerTools
                                 (a.Name != W.rsidRPr) &&
                                 (a.Name != W.rsidSect) &&
                                 (a.Name != W.rsidTr)),
-                element.Nodes().Select(RemoveRsidTransform));
+                element.Nodes().Select(n => RemoveRsidTransform(n)));
         }
 
         private static object MergeAdjacentRunsTransform(XNode node)
@@ -242,7 +242,7 @@ namespace OpenXmlPowerTools
 
             return new XElement(element.Name,
                 element.Attributes(),
-                element.Nodes().Select(MergeAdjacentRunsTransform));
+                element.Nodes().Select(n => MergeAdjacentRunsTransform(n)));
         }
 
         private static object RemoveEmptyRunsAndRunPropertiesTransform(
@@ -257,7 +257,7 @@ namespace OpenXmlPowerTools
 
                 return new XElement(element.Name,
                     element.Attributes(),
-                    element.Nodes().Select(RemoveEmptyRunsAndRunPropertiesTransform));
+                    element.Nodes().Select(n => RemoveEmptyRunsAndRunPropertiesTransform(n)));
             }
 
             return node;
@@ -296,7 +296,7 @@ namespace OpenXmlPowerTools
 
                 return new XElement(element.Name,
                     element.Attributes(),
-                    element.Nodes().Select(MergeAdjacentInstrText));
+                    element.Nodes().Select(n => MergeAdjacentInstrText(n)));
             }
 
             return node;
@@ -537,7 +537,6 @@ namespace OpenXmlPowerTools
                     XElement goBackBookmark = doc
                         .MainDocumentPart
                         .GetXDocument()
-                        .Root?
                         .Descendants(W.bookmarkStart)
                         .FirstOrDefault(bm => (string) bm.Attribute(W.name) == "_GoBack");
                     if (goBackBookmark != null)
@@ -642,7 +641,7 @@ namespace OpenXmlPowerTools
 
             return new XElement(element.Name,
                 element.Attributes(),
-                element.Nodes().Select(SeparateRunChildrenIntoSeparateRuns));
+                element.Nodes().Select(n => SeparateRunChildrenIntoSeparateRuns(n)));
         }
 
         private static object SingleCharacterRunTransform(XNode node)
@@ -672,12 +671,12 @@ namespace OpenXmlPowerTools
                                 element.Elements(W.rPr),
                                 new XElement(sr.Name,
                                     sr.Attributes(),
-                                    sr.Nodes().Select(SingleCharacterRunTransform))));
+                                    sr.Nodes().Select(n => SingleCharacterRunTransform(n)))));
                     });
 
             return new XElement(element.Name,
                 element.Attributes(),
-                element.Nodes().Select(SingleCharacterRunTransform));
+                element.Nodes().Select(n => SingleCharacterRunTransform(n)));
         }
 
         private static class Xsi

--- a/OpenXmlPowerTools/OpenXmlPowerTools.csproj.DotSettings
+++ b/OpenXmlPowerTools/OpenXmlPowerTools.csproj.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp40</s:String>
+</wpf:ResourceDictionary>

--- a/OpenXmlPowerTools/PtUtil.cs
+++ b/OpenXmlPowerTools/PtUtil.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -454,6 +455,7 @@ namespace OpenXmlPowerTools
             }
         }
 
+        [SuppressMessage("ReSharper", "PossibleNullReferenceException")]
         public static IEnumerable<XElement> SiblingsBeforeSelfReverseDocumentOrder(
             this XElement element)
         {
@@ -463,7 +465,7 @@ namespace OpenXmlPowerTools
             while (true)
             {
                 XElement previousElement = current
-                    .Annotation<SiblingsReverseDocumentOrderInfo>()?
+                    .Annotation<SiblingsReverseDocumentOrderInfo>()
                     .PreviousSibling;
                 if (previousElement == null)
                     yield break;
@@ -484,6 +486,7 @@ namespace OpenXmlPowerTools
             }
         }
 
+        [SuppressMessage("ReSharper", "PossibleNullReferenceException")]
         public static IEnumerable<XElement> DescendantsBeforeSelfReverseDocumentOrder(
             this XElement element)
         {
@@ -493,7 +496,7 @@ namespace OpenXmlPowerTools
             while (true)
             {
                 XElement previousElement = current
-                    .Annotation<DescendantsReverseDocumentOrderInfo>()?
+                    .Annotation<DescendantsReverseDocumentOrderInfo>()
                     .PreviousElement;
                 if (previousElement == null)
                     yield break;
@@ -514,6 +517,7 @@ namespace OpenXmlPowerTools
             }
         }
 
+        [SuppressMessage("ReSharper", "PossibleNullReferenceException")]
         public static IEnumerable<XElement> DescendantsTrimmedBeforeSelfReverseDocumentOrder(
             this XElement element, XName trimName)
         {
@@ -528,7 +532,7 @@ namespace OpenXmlPowerTools
             while (true)
             {
                 XElement previousElement = current
-                    .Annotation<DescendantsTrimmedReverseDocumentOrderInfo>()?
+                    .Annotation<DescendantsTrimmedReverseDocumentOrderInfo>()
                     .PreviousElement;
                 if (previousElement == null)
                     yield break;
@@ -736,12 +740,12 @@ namespace OpenXmlPowerTools
                 //    );
                 //
                 var com = xobj as XComment;
-                if (com != null)
+                if (com != null && com.Document != null)
                     return
                         "/" +
                         (
                             com
-                                .Document?
+                                .Document
                                 .Nodes()
                                 .OfType<XComment>()
                                 .Count() != 1
@@ -781,36 +785,36 @@ namespace OpenXmlPowerTools
                         el
                             .Ancestors()
                             .InDocumentOrder()
-                            .Select(NameWithPredicate)
+                            .Select(e => NameWithPredicate(e))
                             .StrCat("/") +
                         NameWithPredicate(el);
                 }
 
                 var at = xobj as XAttribute;
-                if (at != null)
+                if (at != null && at.Parent != null)
                     return
                         "/" +
                         at
-                            .Parent?
+                            .Parent
                             .AncestorsAndSelf()
                             .InDocumentOrder()
-                            .Select(NameWithPredicate)
+                            .Select(e => NameWithPredicate(e))
                             .StrCat("/") +
                         "@" + GetQName(at);
 
                 var com = xobj as XComment;
-                if (com != null)
+                if (com != null && com.Parent != null)
                     return
                         "/" +
                         com
-                            .Parent?
+                            .Parent
                             .AncestorsAndSelf()
                             .InDocumentOrder()
-                            .Select(NameWithPredicate)
+                            .Select(e => NameWithPredicate(e))
                             .StrCat("/") +
                         (
                             com
-                                .Parent?
+                                .Parent
                                 .Nodes()
                                 .OfType<XComment>()
                                 .Count() != 1
@@ -823,18 +827,18 @@ namespace OpenXmlPowerTools
                         );
 
                 var cd = xobj as XCData;
-                if (cd != null)
+                if (cd != null && cd.Parent != null)
                     return
                         "/" +
                         cd
-                            .Parent?
+                            .Parent
                             .AncestorsAndSelf()
                             .InDocumentOrder()
-                            .Select(NameWithPredicate)
+                            .Select(e => NameWithPredicate(e))
                             .StrCat("/") +
                         (
                             cd
-                                .Parent?
+                                .Parent
                                 .Nodes()
                                 .OfType<XText>()
                                 .Count() != 1
@@ -847,18 +851,18 @@ namespace OpenXmlPowerTools
                         );
 
                 var tx = xobj as XText;
-                if (tx != null)
+                if (tx != null && tx.Parent != null)
                     return
                         "/" +
                         tx
-                            .Parent?
+                            .Parent
                             .AncestorsAndSelf()
                             .InDocumentOrder()
-                            .Select(NameWithPredicate)
+                            .Select(e => NameWithPredicate(e))
                             .StrCat("/") +
                         (
                             tx
-                                .Parent?
+                                .Parent
                                 .Nodes()
                                 .OfType<XText>()
                                 .Count() != 1
@@ -871,18 +875,18 @@ namespace OpenXmlPowerTools
                         );
 
                 var pi = xobj as XProcessingInstruction;
-                if (pi != null)
+                if (pi != null && pi.Parent != null)
                     return
                         "/" +
                         pi
-                            .Parent?
+                            .Parent
                             .AncestorsAndSelf()
                             .InDocumentOrder()
-                            .Select(NameWithPredicate)
+                            .Select(e => NameWithPredicate(e))
                             .StrCat("/") +
                         (
                             pi
-                                .Parent?
+                                .Parent
                                 .Nodes()
                                 .OfType<XProcessingInstruction>()
                                 .Count() != 1
@@ -977,7 +981,7 @@ namespace OpenXmlPowerTools
         }
 
         public TKey Key { get; set; }
-        private List<TSource> GroupList { get; }
+        private List<TSource> GroupList { get; set; }
 
         IEnumerator IEnumerable.GetEnumerator()
         {

--- a/OpenXmlPowerTools/WmlToHtmlConverter.cs
+++ b/OpenXmlPowerTools/WmlToHtmlConverter.cs
@@ -1349,7 +1349,7 @@ namespace OpenXmlPowerTools
             var sz = paragraph
                 .DescendantsTrimmed(W.txbxContent)
                 .Where(e => e.Name == W.r)
-                .Select(GetFontSize)
+                .Select(r => GetFontSize(r))
                 .Max();
             if (sz != null)
                 style.AddIfMissing("font-size", string.Format(NumberFormatInfo.InvariantInfo, "{0}pt", sz / 2.0m));
@@ -2514,7 +2514,7 @@ namespace OpenXmlPowerTools
                     if (hasContent == false)
                         return new XElement(element.Name,
                             element.Attributes(),
-                            element.Nodes().Select(InsertAppropriateNonbreakingSpacesTransform),
+                            element.Nodes().Select(n => InsertAppropriateNonbreakingSpacesTransform(n)),
                             new XElement(W.r,
                                 element.Elements(W.pPr).Elements(W.rPr),
                                 new XElement(W.t, " ")));
@@ -2522,7 +2522,7 @@ namespace OpenXmlPowerTools
 
                 return new XElement(element.Name,
                     element.Attributes(),
-                    element.Nodes().Select(InsertAppropriateNonbreakingSpacesTransform));
+                    element.Nodes().Select(n => InsertAppropriateNonbreakingSpacesTransform(n)));
             }
             return node;
         }


### PR DESCRIPTION
This commit replaces the last null-conditional operators. It also sets
the projects' "C# Language Level" properties to "C# 4.0". This
ReSharper property helps ReSharper users avoid language features
introduced with C# 5.0 and later. The rationale is to retain support
for VS2010, which only supports C# 4.0.