### PR TITLE
Use InvariantCulture when converting doubles to and from String

### DIFF
--- a/OpenXmlPowerTools/HtmlToWmlCssApplier.cs
+++ b/OpenXmlPowerTools/HtmlToWmlCssApplier.cs
@@ -354,7 +354,7 @@ namespace OpenXmlPowerTools.HtmlToWml
                 Names = new[] { "font-size" },
                 Inherits = true,
                 Includes = (e, settings) => true,
-                InitialValue = (element, settings) => new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = ((double)settings.DefaultFontSize).ToString(), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.String, Unit = CssUnit.PT } } },
+                InitialValue = (element, settings) => new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = ((double)settings.DefaultFontSize).ToString(CultureInfo.InvariantCulture), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.String, Unit = CssUnit.PT } } },
                 ComputedValue = (element, assignedValue, settings) => ComputeAbsoluteFontSize(element, assignedValue, settings),
             },
 
@@ -901,7 +901,7 @@ namespace OpenXmlPowerTools.HtmlToWml
                         if (rightMargin == null)
                             rightMargin = 1440;
                         double width = (double)(pageWidth - leftMargin - rightMargin) / 20;
-                        return new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = width.ToString(), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.String, Unit = CssUnit.PT, } } };
+                        return new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = width.ToString(CultureInfo.InvariantCulture), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.String, Unit = CssUnit.PT, } } };
                     }
                     return new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "auto", Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.String, } } };
                 },
@@ -934,7 +934,6 @@ namespace OpenXmlPowerTools.HtmlToWml
                         }
                         break;
                     }
-                    //if (valueForPercentage.ToString() == "auto")
 
                     return ComputeAbsoluteLength(element, assignedValue, settings, valueForPercentage);
                 },
@@ -1458,9 +1457,9 @@ namespace OpenXmlPowerTools.HtmlToWml
                 if (unit == CssUnit.PX)
                     newPtSize = decValue * 0.75d;
             }
-            if (newPtSize == null)
+            if (!newPtSize.HasValue)
                 throw new OpenXmlPowerToolsException("Internal error: should not have reached this exception");
-            CssExpression newExpr = new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = newPtSize.ToString(), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } };
+            CssExpression newExpr = new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = newPtSize.Value.ToString(CultureInfo.InvariantCulture), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } };
             return newExpr;
         }
 
@@ -1473,7 +1472,7 @@ namespace OpenXmlPowerTools.HtmlToWml
             if (unit == CssUnit.PT)
                 return assignedValue;
             if (FontSizeMap.ContainsKey(value))
-                return new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = FontSizeMap[value].ToString(), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } };
+                return new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = FontSizeMap[value].ToString(CultureInfo.InvariantCulture), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } };
 
             // todo what should the calculation be for computing larger / smaller?
             if (value == "larger" || value == "smaller")
@@ -1513,7 +1512,7 @@ namespace OpenXmlPowerTools.HtmlToWml
                     if (ptSize >= 30)
                         newPtSize2 = 24d;
                 }
-                return new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = newPtSize2.ToString(), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } };
+                return new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = newPtSize2.ToString(CultureInfo.InvariantCulture), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } };
             }
             double decValue;
             if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out decValue))
@@ -1545,9 +1544,9 @@ namespace OpenXmlPowerTools.HtmlToWml
                 if (unit == CssUnit.PX)
                     newPtSize = decValue * 0.75d;
             }
-            if (newPtSize == null)
+            if (!newPtSize.HasValue)
                 throw new OpenXmlPowerToolsException("Internal error: should not have reached this exception");
-            CssExpression newExpr = new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = newPtSize.ToString(), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } };
+            CssExpression newExpr = new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = newPtSize.Value.ToString(CultureInfo.InvariantCulture), Type = OpenXmlPowerTools.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } };
             return newExpr;
         }
 

--- a/OpenXmlPowerTools/HtmlToWmlCssParser.cs
+++ b/OpenXmlPowerTools/HtmlToWmlCssParser.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -585,18 +586,18 @@ namespace OpenXmlPowerTools.HtmlToWml.CSS
 
         public static explicit operator double(CssExpression e)
         {
-            return double.Parse(e.Terms.First().Value);
+            return double.Parse(e.Terms.First().Value, CultureInfo.InvariantCulture);
         }
 
         public static explicit operator Emu(CssExpression e)
         {
-            return Emu.PointsToEmus(double.Parse(e.Terms.First().Value));
+            return Emu.PointsToEmus(double.Parse(e.Terms.First().Value, CultureInfo.InvariantCulture));
         }
 
         // will only be called on expression that is in terms of points
         public static explicit operator TPoint(CssExpression e)
         {
-            return new TPoint(double.Parse(e.Terms.First().Value));
+            return new TPoint(double.Parse(e.Terms.First().Value, CultureInfo.InvariantCulture));
         }
 
         // will only be called on expression that is in terms of points
@@ -608,7 +609,7 @@ namespace OpenXmlPowerTools.HtmlToWml.CSS
                 if (term.Unit == CssUnit.PT)
                 {
                     double ptValue;
-                    if (double.TryParse(term.Value.ToString(), out ptValue))
+                    if (double.TryParse(term.Value.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out ptValue))
                     {
                         if (term.Sign == '-')
                             ptValue = -ptValue;

--- a/OpenXmlPowerTools/SmlCellFormatter.cs
+++ b/OpenXmlPowerTools/SmlCellFormatter.cs
@@ -81,7 +81,7 @@ namespace OpenXmlPowerTools
             if (splitFormatCode.Length == 1)
             {
                 double dv;
-                if (double.TryParse(value, out dv))
+                if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out dv))
                 {
                     return FormatDouble(formatCode, dv, out color);
                 }
@@ -90,7 +90,7 @@ namespace OpenXmlPowerTools
             if (splitFormatCode.Length == 2)
             {
                 double dv;
-                if (double.TryParse(value, out dv))
+                if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out dv))
                 {
                     if (dv > 0)
                     {
@@ -109,7 +109,7 @@ namespace OpenXmlPowerTools
             if (splitFormatCode.Length == 4)
             {
                 double dv;
-                if (double.TryParse(value, out dv))
+                if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out dv))
                 {
                     if (dv > 0)
                     {
@@ -211,7 +211,7 @@ namespace OpenXmlPowerTools
 
 
             if (formatCode == "General")
-                return dv.ToString();
+                return dv.ToString(CultureInfo.InvariantCulture);
             bool isDate = IsFormatCodeForDate(formatCode);
             var cfc = ConvertFormatCode(formatCode);
             if (isDate)
@@ -223,7 +223,7 @@ namespace OpenXmlPowerTools
                 }
                 catch (ArgumentException)
                 {
-                    return dv.ToString();
+                    return dv.ToString(CultureInfo.InvariantCulture);
                 }
                 if (cfc.StartsWith("[h]"))
                 {
@@ -239,23 +239,23 @@ namespace OpenXmlPowerTools
                     var s4 = thisDate.ToString(cfc2).Trim();
                     return s4;
                 }
-                var s2 = thisDate.ToString(cfc).Trim();
+                var s2 = thisDate.ToString(cfc, CultureInfo.InvariantCulture).Trim();
                 return s2;
             }
             if (ExcelFormatCodeToNetFormatCodeExceptionMap.ContainsKey(formatCode))
             {
                 FormatConfig fc = ExcelFormatCodeToNetFormatCodeExceptionMap[formatCode];
-                var s = dv.ToString(fc.FormatCode).Trim();
+                var s = dv.ToString(fc.FormatCode, CultureInfo.InvariantCulture).Trim();
                 return s;
             }
             if ((cfc.Contains('(') && cfc.Contains(')')) || cfc.Contains('-'))
             {
-                var s3 = (-dv).ToString(cfc).Trim();
+                var s3 = (-dv).ToString(cfc, CultureInfo.InvariantCulture).Trim();
                 return s3;
             }
             else
             {
-                var s4 = dv.ToString(cfc).Trim();
+                var s4 = dv.ToString(cfc, CultureInfo.InvariantCulture).Trim();
                 return s4;
             }
         }


### PR DESCRIPTION
When running the units tests on a machine with the Swedish culture set a number of them fail, this is also a problem when using the library. Here are two open issues caused by this: #52, #75. #38 is a closed issue that tried to address the problem, but missed  a couple of spots.

Here I have tried to fix the remaining issues, now all tests pass for me using either en-US or sv-SE as my culture.

