### PR TITLE
Unicodemapper and NuGet package fix

### DIFF
--- a/OpenXmlPowerTools.Tests/OpenXmlPowerTools.Tests.csproj
+++ b/OpenXmlPowerTools.Tests/OpenXmlPowerTools.Tests.csproj
@@ -33,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/OpenXmlPowerTools.Tests/packages.config
+++ b/OpenXmlPowerTools.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />

--- a/OpenXmlPowerTools/OpenXmlPowerTools.csproj
+++ b/OpenXmlPowerTools/OpenXmlPowerTools.csproj
@@ -31,8 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/OpenXmlPowerTools/OpenXmlPowerTools.csproj
+++ b/OpenXmlPowerTools/OpenXmlPowerTools.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\One-Check-Transformation\OecdAuthoring\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/ChartUpdater01/ChartUpdater01.csproj
+++ b/OpenXmlPowerToolsExamples/ChartUpdater01/ChartUpdater01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/ChartUpdater01/packages.config
+++ b/OpenXmlPowerToolsExamples/ChartUpdater01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/DocumentAssembler/DocumentAssembler.csproj
+++ b/OpenXmlPowerToolsExamples/DocumentAssembler/DocumentAssembler.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/DocumentAssembler/packages.config
+++ b/OpenXmlPowerToolsExamples/DocumentAssembler/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/DocumentAssembler01/DocumentAssembler01.csproj
+++ b/OpenXmlPowerToolsExamples/DocumentAssembler01/DocumentAssembler01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/DocumentAssembler01/packages.config
+++ b/OpenXmlPowerToolsExamples/DocumentAssembler01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/DocumentAssembler02/DocumentAssembler02.csproj
+++ b/OpenXmlPowerToolsExamples/DocumentAssembler02/DocumentAssembler02.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/DocumentAssembler02/packages.config
+++ b/OpenXmlPowerToolsExamples/DocumentAssembler02/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/DocumentAssembler03/DocumentAssembler03.csproj
+++ b/OpenXmlPowerToolsExamples/DocumentAssembler03/DocumentAssembler03.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/DocumentAssembler03/packages.config
+++ b/OpenXmlPowerToolsExamples/DocumentAssembler03/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/DocumentBuilder01/DocumentBuilder01.csproj
+++ b/OpenXmlPowerToolsExamples/DocumentBuilder01/DocumentBuilder01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/DocumentBuilder01/packages.config
+++ b/OpenXmlPowerToolsExamples/DocumentBuilder01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/DocumentBuilder02/DocumentBuilder02.csproj
+++ b/OpenXmlPowerToolsExamples/DocumentBuilder02/DocumentBuilder02.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/DocumentBuilder02/packages.config
+++ b/OpenXmlPowerToolsExamples/DocumentBuilder02/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/DocumentBuilder03/DocumentBuilder03.csproj
+++ b/OpenXmlPowerToolsExamples/DocumentBuilder03/DocumentBuilder03.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/DocumentBuilder03/packages.config
+++ b/OpenXmlPowerToolsExamples/DocumentBuilder03/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/DocumentBuilder04/DocumentBuilder04.csproj
+++ b/OpenXmlPowerToolsExamples/DocumentBuilder04/DocumentBuilder04.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/DocumentBuilder04/packages.config
+++ b/OpenXmlPowerToolsExamples/DocumentBuilder04/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/FieldRetriever01/FieldRetriever01.csproj
+++ b/OpenXmlPowerToolsExamples/FieldRetriever01/FieldRetriever01.csproj
@@ -32,9 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/OpenXmlPowerToolsExamples/FieldRetriever01/packages.config
+++ b/OpenXmlPowerToolsExamples/FieldRetriever01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/FormattingAssembler01/FormattingAssembler01.csproj
+++ b/OpenXmlPowerToolsExamples/FormattingAssembler01/FormattingAssembler01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/FormattingAssembler01/packages.config
+++ b/OpenXmlPowerToolsExamples/FormattingAssembler01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/Formulas01/Formulas01.csproj
+++ b/OpenXmlPowerToolsExamples/Formulas01/Formulas01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/Formulas01/packages.config
+++ b/OpenXmlPowerToolsExamples/Formulas01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/HtmlConverter01/HtmlConverter01.csproj
+++ b/OpenXmlPowerToolsExamples/HtmlConverter01/HtmlConverter01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/HtmlConverter01/packages.config
+++ b/OpenXmlPowerToolsExamples/HtmlConverter01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/HtmlToWmlConverter01/HtmlToWmlConverter01.csproj
+++ b/OpenXmlPowerToolsExamples/HtmlToWmlConverter01/HtmlToWmlConverter01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/HtmlToWmlConverter01/packages.config
+++ b/OpenXmlPowerToolsExamples/HtmlToWmlConverter01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/HtmlToWmlConverter02/HtmlToWmlConverter02.csproj
+++ b/OpenXmlPowerToolsExamples/HtmlToWmlConverter02/HtmlToWmlConverter02.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/HtmlToWmlConverter02/packages.config
+++ b/OpenXmlPowerToolsExamples/HtmlToWmlConverter02/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/ListItemRetriever01/ListItemRetriever01.csproj
+++ b/OpenXmlPowerToolsExamples/ListItemRetriever01/ListItemRetriever01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/ListItemRetriever01/packages.config
+++ b/OpenXmlPowerToolsExamples/ListItemRetriever01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/MarkupSimplifierApp/MarkupSimplifierApp.csproj
+++ b/OpenXmlPowerToolsExamples/MarkupSimplifierApp/MarkupSimplifierApp.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/MarkupSimplifierApp/packages.config
+++ b/OpenXmlPowerToolsExamples/MarkupSimplifierApp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/MetricsGetter01/MetricsGetter01.csproj
+++ b/OpenXmlPowerToolsExamples/MetricsGetter01/MetricsGetter01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/MetricsGetter01/packages.config
+++ b/OpenXmlPowerToolsExamples/MetricsGetter01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/OpenXmlRegex01/OpenXmlRegex01.csproj
+++ b/OpenXmlPowerToolsExamples/OpenXmlRegex01/OpenXmlRegex01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/OpenXmlRegex01/packages.config
+++ b/OpenXmlPowerToolsExamples/OpenXmlRegex01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/PivotTables01/PivotTables01.csproj
+++ b/OpenXmlPowerToolsExamples/PivotTables01/PivotTables01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/PivotTables01/packages.config
+++ b/OpenXmlPowerToolsExamples/PivotTables01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/PresentationBuilder01/PresentationBuilder01.csproj
+++ b/OpenXmlPowerToolsExamples/PresentationBuilder01/PresentationBuilder01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/PresentationBuilder01/packages.config
+++ b/OpenXmlPowerToolsExamples/PresentationBuilder01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/PresentationBuilder02/PresentationBuilder02.csproj
+++ b/OpenXmlPowerToolsExamples/PresentationBuilder02/PresentationBuilder02.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/PresentationBuilder02/packages.config
+++ b/OpenXmlPowerToolsExamples/PresentationBuilder02/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/ReferenceAdder01/ReferenceAdder01.csproj
+++ b/OpenXmlPowerToolsExamples/ReferenceAdder01/ReferenceAdder01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/ReferenceAdder01/packages.config
+++ b/OpenXmlPowerToolsExamples/ReferenceAdder01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/RevisionAccepter01/RevisionAccepter01.csproj
+++ b/OpenXmlPowerToolsExamples/RevisionAccepter01/RevisionAccepter01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/RevisionAccepter01/packages.config
+++ b/OpenXmlPowerToolsExamples/RevisionAccepter01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/SmlDataRetriever01/SmlDataRetriever01.csproj
+++ b/OpenXmlPowerToolsExamples/SmlDataRetriever01/SmlDataRetriever01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/SmlDataRetriever01/packages.config
+++ b/OpenXmlPowerToolsExamples/SmlDataRetriever01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/SpreadsheetWriter01/SpreadsheetWriter01.csproj
+++ b/OpenXmlPowerToolsExamples/SpreadsheetWriter01/SpreadsheetWriter01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/SpreadsheetWriter01/packages.config
+++ b/OpenXmlPowerToolsExamples/SpreadsheetWriter01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/SpreadsheetWriter02/SpreadsheetWriter02.csproj
+++ b/OpenXmlPowerToolsExamples/SpreadsheetWriter02/SpreadsheetWriter02.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/SpreadsheetWriter02/packages.config
+++ b/OpenXmlPowerToolsExamples/SpreadsheetWriter02/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/TextReplacer01/TextReplacer01.csproj
+++ b/OpenXmlPowerToolsExamples/TextReplacer01/TextReplacer01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/TextReplacer01/packages.config
+++ b/OpenXmlPowerToolsExamples/TextReplacer01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/TextReplacer02/TextReplacer02.csproj
+++ b/OpenXmlPowerToolsExamples/TextReplacer02/TextReplacer02.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/TextReplacer02/packages.config
+++ b/OpenXmlPowerToolsExamples/TextReplacer02/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/WmlComparer01/WmlComparer01.csproj
+++ b/OpenXmlPowerToolsExamples/WmlComparer01/WmlComparer01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/WmlComparer01/packages.config
+++ b/OpenXmlPowerToolsExamples/WmlComparer01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/WmlComparer02/WmlComparer02.csproj
+++ b/OpenXmlPowerToolsExamples/WmlComparer02/WmlComparer02.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/WmlComparer02/packages.config
+++ b/OpenXmlPowerToolsExamples/WmlComparer02/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/WmlToHtmlConverter01/WmlToHtmlConverter01.csproj
+++ b/OpenXmlPowerToolsExamples/WmlToHtmlConverter01/WmlToHtmlConverter01.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/WmlToHtmlConverter01/packages.config
+++ b/OpenXmlPowerToolsExamples/WmlToHtmlConverter01/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>

--- a/OpenXmlPowerToolsExamples/WmlToHtmlConverter02/WmlToHtmlConverter02.csproj
+++ b/OpenXmlPowerToolsExamples/WmlToHtmlConverter02/WmlToHtmlConverter02.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=0.0.1.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2-vnext0027\lib\net45\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/OpenXmlPowerToolsExamples/WmlToHtmlConverter02/packages.config
+++ b/OpenXmlPowerToolsExamples/WmlToHtmlConverter02/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2-vnext0027" targetFramework="net45" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This pull request primarily fixes the UnicodeMapper class, which is used in conjunction with the OpenXmlRegex class. As a "secondary" fix, it makes sure that v2.7.2 of the DocumentFormat.OpenXml.dll is used consistently in the OpenXmlPowerTools and OpenXmlPowerToolsExamples solutions.

Please see the commit messages for details.