### PR TITLE
WorksheetAccessor.cs CreatePivotTable null values

### DIFF
--- a/OpenXmlPowerTools/WorksheetAccessor.cs
+++ b/OpenXmlPowerTools/WorksheetAccessor.cs
@@ -571,11 +571,13 @@ namespace OpenXmlPowerTools
                     {
                         value = GetCellValue(document, sourceSheet, column, row);
                         if (value is double)
+                        {
                             hasDouble = true;
-                        if (Convert.ToDouble(value) < minValue)
-                            minValue = Convert.ToDouble(value);
-                        if (Convert.ToDouble(value) > maxValue)
-                            maxValue = Convert.ToDouble(value);
+                            if (Convert.ToDouble(value) < minValue)
+                                minValue = Convert.ToDouble(value);
+                            if (Convert.ToDouble(value) > maxValue)
+                                maxValue = Convert.ToDouble(value);
+                        }
                     }
                     sharedItems.Add(new XAttribute(NoNamespace.containsSemiMixedTypes, "0"),
                         new XAttribute(NoNamespace.containsString, "0"), new XAttribute(NoNamespace.containsNumber, "1"),


### PR DESCRIPTION
When CreatePivotTable is called on a range, it does not check for doubles past (startRow + 1) in a given column.  Curly braces were added in the row for-loop so that it won't break trying to convert an empty value to double.