### PR TITLE
Added support for SVG graphics to the PresentationBuilder

### DIFF
--- a/OpenXmlPowerTools/PresentationBuilder.cs
+++ b/OpenXmlPowerTools/PresentationBuilder.cs
@@ -659,7 +659,7 @@ namespace OpenXmlPowerTools
             IEnumerable<XElement> newContent, List<ImageData> images, List<MediaData> mediaList)
         {
             var relevantElements = newContent.DescendantsAndSelf()
-                .Where(d => d.Name == VML.imagedata || d.Name == VML.fill || d.Name == VML.stroke || d.Name == A.blip)
+                .Where(d => d.Name == VML.imagedata || d.Name == VML.fill || d.Name == VML.stroke || d.Name == A.blip || d.Name == SVG.blip)
                 .ToList();
             foreach (XElement imageReference in relevantElements)
             {

--- a/OpenXmlPowerTools/PtOpenXmlUtil.cs
+++ b/OpenXmlPowerTools/PtOpenXmlUtil.cs
@@ -4668,6 +4668,13 @@ listSeparator
         public static readonly XName slicer = sle + "slicer";
     }
 
+    public static class SVG
+    {
+        public static readonly XNamespace svg =
+            "http://schemas.microsoft.com/office/drawing/2016/SVG/main";
+        public static readonly XName blip = svg + "svgBlip";
+    }
+
     public static class VML
     {
         public static readonly XNamespace vml =


### PR DESCRIPTION
While merging presentations SVG graphics where ignored at CopyRelatedPartsForContentParts and showed up as defect in the generated file.