### PR TITLE
Update ChartUpdater.cs

### DIFF
--- a/OpenXmlPowerTools/ChartUpdater.cs
+++ b/OpenXmlPowerTools/ChartUpdater.cs
@@ -355,7 +355,7 @@ namespace OpenXmlPowerTools
                             firstSeries.Elements(C.smooth),
                             firstSeries.Elements(C.extLst));
                     }
-                    else if (chartType == C.doughnutChart || chartType == C.ofPieChart || chartType == C.pie3DChart || chartType == C.pieChart)
+                    else if (chartType == C.doughnutChart || chartType == C.ofPieChart || chartType == C.pie3DChart || chartType == C.pieChart || chartType == C.radarChart)
                     {
                         newSer = new XElement(C.ser,
                             // common


### PR DESCRIPTION
UpdateChart.UpdateChart.UpdateSeries does not work on Radar chart types, it is a simple one line fix that I have used for a few years now.
Closes OfficeDev/Open-Xml-PowerTools#245