### PR TITLE
Fix issue related to text-align with rtl direction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ TestResults/
 # JetBrains
 .idea/
 _ReSharper.Caches/
+/OpenXmlPowerTools/Properties/PublishProfiles

--- a/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
+++ b/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
@@ -3111,6 +3111,8 @@ namespace OpenXmlPowerTools.HtmlToWml
             {
                 if (textAlign == "right")
                     jc = "right";
+                if (textAlign == "left")
+                    jc = "left";
                 else
                 {
                     if (textAlign == "justify")

--- a/OpenXmlPowerToolsExamples/HtmlToWmlConverter01/Arabic.html
+++ b/OpenXmlPowerToolsExamples/HtmlToWmlConverter01/Arabic.html
@@ -1,0 +1,17 @@
+﻿<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head dir="auto" lang="ar">
+    <title></title>
+    <meta charset="utf-8" />
+
+</head>
+<body>
+    <div style="text-align:left;direction:rtl">
+        اللغة العربية 
+    </div>
+    <div style="text-align:left;direction:rtl">
+        English item
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
When adding style="direction:rtl; text-align:left" it doesn't apply text-align property.